### PR TITLE
Set Static IP for Pico W Access Point

### DIFF
--- a/code.py
+++ b/code.py
@@ -1,5 +1,6 @@
 import socketpool
 import wifi
+import ipaddress
 import usb_hid
 from adafruit_httpserver import Server, Request, Response, GET, POST
 from adafruit_hid.keyboard import Keyboard
@@ -11,6 +12,8 @@ layout = KeyboardLayoutUS(kbd)
 
 
 wifi.radio.start_ap(ssid="picow-keyboard", password="picow-keyboard")
+wifi.radio.set_ipv4_address_ap(ipv4=ipaddress.IPv4Address("192.168.1.1"), netmask=ipaddress.IPv4Address("255.255.255.0"), gateway=ipaddress.IPv4Address("192.168.1.1"))
+wifi.radio.start_dhcp_ap()
 pool = socketpool.SocketPool(wifi.radio)
 server = Server(pool, debug=True)
 


### PR DESCRIPTION
## Description

This PR configures the **Pico W access point** to use a **static IP address (`192.168.1.1`)** instead of the default dynamic assignment. This ensures a consistent entry point for the web interface.

### Changes

- Imported the `ipaddress` module.  
- Configured `wifi.radio.set_ipv4_address_ap` with:
  - **IP:** `192.168.1.1`
  - **Netmask:** `255.255.255.0`
  - **Gateway:** `192.168.1.1`
- Added `wifi.radio.start_dhcp_ap()` to ensure the DHCP server runs after setting the static IP.

## Related Issue
Closes #4 

## Motivation

Users previously experienced variability in the AP's IP address (e.g., `192.168.1.4`), making it difficult to reliably access the web interface.  
A static IP provides a predictable and consistent URL.


